### PR TITLE
Updated AL-Go System Files

### DIFF
--- a/.AL-Go/cloudDevEnv.ps1
+++ b/.AL-Go/cloudDevEnv.ps1
@@ -27,11 +27,11 @@ Write-Host -ForegroundColor Yellow @'
 $webClient = New-Object System.Net.WebClient
 $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumentList ([System.Net.Cache.RequestCacheLevel]::NoCacheNoStore)
 $webClient.Encoding = [System.Text.Encoding]::UTF8
-$GitHubHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v4.0/Github-Helper.psm1'
+$GitHubHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go/fc491ffce4cc911d677b3b4318a9372fbe54141e/Actions/Github-Helper.psm1'
 Write-Host "Downloading GitHub Helper module from $GitHubHelperUrl"
 $GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
 $webClient.DownloadFile($GitHubHelperUrl, $GitHubHelperPath)
-$ALGoHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v4.0/AL-Go-Helper.ps1'
+$ALGoHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go/fc491ffce4cc911d677b3b4318a9372fbe54141e/Actions/AL-Go-Helper.ps1'
 Write-Host "Downloading AL-Go Helper script from $ALGoHelperUrl"
 $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
 $webClient.DownloadFile($ALGoHelperUrl, $ALGoHelperPath)

--- a/.AL-Go/localDevEnv.ps1
+++ b/.AL-Go/localDevEnv.ps1
@@ -30,11 +30,11 @@ Write-Host -ForegroundColor Yellow @'
 $webClient = New-Object System.Net.WebClient
 $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumentList ([System.Net.Cache.RequestCacheLevel]::NoCacheNoStore)
 $webClient.Encoding = [System.Text.Encoding]::UTF8
-$GitHubHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v4.0/Github-Helper.psm1'
+$GitHubHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go/fc491ffce4cc911d677b3b4318a9372fbe54141e/Actions/Github-Helper.psm1'
 Write-Host "Downloading GitHub Helper module from $GitHubHelperUrl"
 $GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
 $webClient.DownloadFile($GitHubHelperUrl, $GitHubHelperPath)
-$ALGoHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v4.0/AL-Go-Helper.ps1'
+$ALGoHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go/fc491ffce4cc911d677b3b4318a9372fbe54141e/Actions/AL-Go-Helper.ps1'
 Write-Host "Downloading AL-Go Helper script from $ALGoHelperUrl"
 $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
 $webClient.DownloadFile($ALGoHelperUrl, $ALGoHelperPath)

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -1,4 +1,4 @@
 {
   "type": "PTE",
-  "templateUrl": "https://github.com/microsoft/AL-Go-PTE@main"
+  "templateUrl": "https://github.com/freddydk/MyPTE@preview"
 }

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -1,3 +1,47 @@
+## Preview
+
+Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.
+
+### New Settings
+- `templateSha`: The SHA of the version of AL-Go currently used
+
+### New Actions
+- `DumpWorkflowInfo`: Dump information about running workflow
+- `Troubleshooting` : Run troubleshooting for repository
+
+### Update AL-Go System Files
+Add another parameter when running Update AL-Go System Files, called downloadLatest, used to indicate whether to download latest version from template repository. Default value is true.
+If false, the templateSha repository setting is used to download specific AL-Go System Files when calculating new files.
+
+### Issues
+- Issue 782 Exclude '.altestrunner/' from template .gitignore
+- Issue 823 Dependencies from prior build jobs are not included when using useProjectDependencies
+- App artifacts for version 'latest' are now fetched from the latest CICD run that completed and successfully built all the projects for the corresponding branch.
+- Issue 824 Utilize `useCompilerFolder` setting when creating an development environment for an AL-Go project.
+- Issue 828 and 825 display warnings for secrets, which might cause AL-Go for GitHub to malfunction
+
+### New Settings
+
+- `alDoc` : JSON object with properties for the ALDoc reference document generation
+  - **continuousDeployment** = Determines if reference documentation will be deployed continuously as part of CI/CD. You can run the **Deploy Reference Documentation** workflow to deploy manually or on a schedule. (Default false)
+  - **deployToGitHubPages** = Determines whether or not the reference documentation site should be deployed to GitHub Pages for the repository. In order to deploy to GitHub Pages, GitHub Pages must be enabled and set to GitHub Actions. (Default true)
+  - **maxReleases** = Maximum number of releases to include in the reference documentation. (Default 3)
+  - **groupByProject** = Determines whether projects in multi-project repositories are used as folders in reference documentation
+  - **includeProjects** = An array of projects to include in the reference documentation. (Default all)
+  - **excludeProjects** = An array of projects to exclude in the reference documentation. (Default none)-
+  - **header** = Header for the documentation site. (Default: Documentation for...)
+  - **footer** = Footer for the documentation site. (Default: Made with...)
+  - **defaultIndexMD** = Markdown for the landing page of the documentation site. (Default: Reference documentation...)
+  - **defaultReleaseMD** = Markdown for the landing page of the release sites. (Default: Release reference documentation...)
+  - *Note that in header, footer, defaultIndexMD and defaultReleaseMD you can use the following placeholders: {REPOSITORY}, {VERSION}, {INDEXTEMPLATERELATIVEPATH}, {RELEASENOTES}* 
+
+### New Workflows
+- **Deploy Reference Documentation** is a workflow, which you can invoke manually or on a schedule to generate and deploy reference documentation using the aldoc tool, using the ALDoc setting properties described above.
+- **Troubleshooting** is a workflow, which you can invoke manually to run troubleshooting on the repository and check for settings or secrets, containing illegal values. When creating issues on https://github.com/microsoft/AL-Go/issues, we might ask you to run the troubleshooter to help identify common problems.
+
+### Support for ALDoc reference documentation tool
+ALDoc reference documentation tool is now supported for generating and deploying reference documentation for your projects either continuously or manually/scheduled.
+
 ## v4.0
 
 ### Removal of the InsiderSasToken

--- a/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -13,12 +13,13 @@ on:
         description: Direct Download Url of .app or .zip file
         required: true
       directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Direct Commit?
         type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -34,26 +35,32 @@ env:
 
 jobs:
   AddExistingAppOrTestApp:
+    needs: [ ]
     runs-on: [ windows-latest ]
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0090"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -61,7 +68,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Add existing app
-        uses: microsoft/AL-Go-Actions/AddExistingApp@v4.0
+        uses: microsoft/AL-Go/Actions/AddExistingApp@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -72,7 +79,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0090"

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -24,12 +24,15 @@ env:
 
 jobs:
   Initialization:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       environmentsMatrixJson: ${{ steps.DetermineDeploymentEnvironments.outputs.EnvironmentsMatrixJson }}
       environmentCount: ${{ steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount }}
       deploymentEnvironmentsJson: ${{ steps.DetermineDeploymentEnvironments.outputs.DeploymentEnvironmentsJson }}
+      generateALDocArtifact: ${{ steps.DetermineDeploymentEnvironments.outputs.GenerateALDocArtifact }}
+      deployALDocArtifact: ${{ steps.DetermineDeploymentEnvironments.outputs.DeployALDocArtifact }}
       deliveryTargetsJson: ${{ steps.DetermineDeliveryTargets.outputs.DeliveryTargetsJson }}
       githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
       githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
@@ -38,6 +41,11 @@ jobs:
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -45,14 +53,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0091"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           get: type
@@ -64,22 +72,22 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v4.0
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v4.0
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
-          checkContextSecrets: 'N'
+          checkContextSecrets: 'false'
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -87,17 +95,17 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v4.0
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
-          checkContextSecrets: 'Y'
+          checkContextSecrets: 'true'
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v4.0
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@fc491ffce4cc911d677b3b4318a9372fbe54141e
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -106,24 +114,24 @@ jobs:
           type: 'CD'
 
   CheckForUpdates:
-    runs-on: [ windows-latest ]
     needs: [ Initialization ]
+    runs-on: [ windows-latest ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           get: templateUrl
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v4.0
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           templateUrl: ${{ env.templateUrl }}
+          downloadLatest: true
 
   Build:
     needs: [ Initialization ]
@@ -149,6 +157,53 @@ jobs:
       signArtifacts: true
       useArtifactCache: true
 
+  DeployALDoc:
+    needs: [ Initialization, Build ]
+    if: always() && needs.Build.result == 'Success' && needs.Initialization.outputs.generateALDocArtifact == 1 && github.ref_name == 'main'
+    runs-on: windows-latest
+    name: Deploy Reference Documentation
+    permissions:
+      contents: write
+      actions: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: '.artifacts'
+
+      - name: Read settings
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
+      - name: Setup Pages
+        if: needs.Initialization.outputs.deployALDocArtifact == 1
+        uses: actions/configure-pages@v3
+
+      - name: Build Reference Documentation
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+          artifacts: '.artifacts'
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ".aldoc/_site/"
+
+      - name: Deploy to GitHub Pages
+        if: needs.Initialization.outputs.deployALDocArtifact == 1
+        id: deployment
+        uses: actions/deploy-pages@v2
+
   Deploy:
     needs: [ Initialization, Build ]
     if: always() && needs.Build.result == 'Success' && needs.Initialization.outputs.environmentCount > 0
@@ -168,7 +223,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
@@ -181,7 +236,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -189,7 +244,7 @@ jobs:
 
       - name: Deploy
         id: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v4.0
+        uses: microsoft/AL-Go/Actions/Deploy@fc491ffce4cc911d677b3b4318a9372fbe54141e
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -218,20 +273,20 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: microsoft/AL-Go-Actions/Deliver@v4.0
+        uses: microsoft/AL-Go/Actions/Deliver@fc491ffce4cc911d677b3b4318a9372fbe54141e
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -242,16 +297,16 @@ jobs:
           artifacts: '.artifacts'
 
   PostProcess:
+    needs: [ Initialization, Build, Deploy, Deliver, DeployALDoc ]
     if: (!cancelled())
     runs-on: [ windows-latest ]
-    needs: [ Initialization, Build, Deploy, Deliver ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0091"

--- a/.github/workflows/CreateApp.yaml
+++ b/.github/workflows/CreateApp.yaml
@@ -19,16 +19,17 @@ on:
         description: ID range (from..to)
         required: true
       sampleCode:
-        description: Include Sample code (Y/N)
-        required: false
-        default: 'Y'
-      directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: "N"
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Include Sample code?
         type: boolean
+        default: true
+      directCommit:
+        description: Direct Commit?
+        type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -44,27 +45,33 @@ env:
 
 jobs:
   CreateApp:
+    needs: [ ]
     runs-on: [ windows-latest ]
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0092"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           get: type
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -72,7 +79,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new app
-        uses: microsoft/AL-Go-Actions/CreateApp@v4.0
+        uses: microsoft/AL-Go/Actions/CreateApp@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -87,7 +94,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0092"

--- a/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -13,16 +13,17 @@ on:
         description: Name of the online environment
         required: true
       reUseExistingEnvironment:
-        description: Reuse environment if it exists
-        required: false
-        default: 'N'
-      directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Reuse environment if it exists?
         type: boolean
+        default: false
+      directCommit:
+        description: Direct Commit?
+        type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -38,6 +39,7 @@ env:
 
 jobs:
   Initialization:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       deviceCode: ${{ steps.authenticate.outputs.deviceCode }}
@@ -45,25 +47,30 @@ jobs:
       githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
       githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0093"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -82,7 +89,7 @@ jobs:
             Write-Host "AdminCenterApiCredentials not provided, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v4.0/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go/fc491ffce4cc911d677b3b4318a9372fbe54141e/Actions/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -91,12 +98,12 @@ jobs:
           }
 
   CreateDevelopmentEnvironment:
+    needs: [ Initialization ]
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:
         shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
     name: Create Development Environment
-    needs: [ Initialization ]
     env:
       deviceCode: ${{ needs.Initialization.outputs.deviceCode }}
     steps:
@@ -104,13 +111,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -129,7 +136,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -value "adminCenterApiCredentials=$adminCenterApiCredentials"
 
       - name: Create Development Environment
-        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@v4.0
+        uses: microsoft/AL-Go/Actions/CreateDevelopmentEnvironment@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -142,7 +149,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0093"

--- a/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/.github/workflows/CreatePerformanceTestApp.yaml
@@ -21,20 +21,21 @@ on:
         required: true
         default: '50000..99999'
       sampleCode:
-        description: Include Sample code (Y/N)
-        required: false
-        default: 'Y'
-      sampleSuite:
-        description: Include Sample BCPT Suite (Y/N)
-        required: false
-        default: 'Y'
-      directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Include Sample code?
         type: boolean
+        default: true
+      sampleSuite:
+        description: Include Sample BCPT Suite?
+        type: boolean
+        default: true
+      directCommit:
+        description: Direct Commit?
+        type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -50,26 +51,32 @@ env:
 
 jobs:
   CreatePerformanceTestApp:
+    needs: [ ]
     runs-on: [ windows-latest ]
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0102"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -77,7 +84,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v4.0
+        uses: microsoft/AL-Go/Actions/CreateApp@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -93,7 +100,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0102"

--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -16,28 +16,29 @@ on:
         required: true
         default: ''
       prerelease:
-        description: Prerelease (Y/N)
-        required: false
-        default: 'N'
+        description: Prerelease?
+        type: boolean
+        default: false
       draft:
-        description: Draft (Y/N)
-        required: false
-        default: 'N'
+        description: Draft?
+        type: boolean
+        default: false
       createReleaseBranch:
-        description: Create Release Branch (Y/N)
-        required: false
-        default: 'N'
+        description: Create Release Branch?
+        type: boolean
+        default: false
       updateVersionNumber:
         description: New Version Number in main branch. Use Major.Minor for absolute change, use +Major.Minor for incremental change.
         required: false
         default: ''
       directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Direct Commit?
         type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -56,6 +57,7 @@ env:
 
 jobs:
   CreateRelease:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -64,35 +66,40 @@ jobs:
       commitish: ${{ steps.analyzeartifacts.outputs.commitish }}
       releaseBranch: ${{ steps.createreleasenotes.outputs.releaseBranch }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0094"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           get: templateUrl,repoName
 
       - name: Determine Projects
         id: determineProjects
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v4.0
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v4.0
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           templateUrl: ${{ env.templateUrl }}
+          downloadLatest: true
 
       - name: Analyze Artifacts
         id: analyzeartifacts
@@ -173,7 +180,7 @@ jobs:
 
       - name: Prepare release notes
         id: createreleasenotes
-        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@v4.0
+        uses: microsoft/AL-Go/Actions/CreateReleaseNotes@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -195,8 +202,8 @@ jobs:
               tag_name: '${{ github.event.inputs.tag }}',
               name: '${{ github.event.inputs.name }}',
               body: bodyMD.replaceAll('\\n','\n').replaceAll('%0A','\n').replaceAll('%0D','\n').replaceAll('%25','%'),
-              draft: ${{ github.event.inputs.draft=='Y' }},
-              prerelease: ${{ github.event.inputs.prerelease=='Y' }},
+              draft: ${{ github.event.inputs.draft=='true' }},
+              prerelease: ${{ github.event.inputs.prerelease=='true' }},
               make_latest: 'legacy',
               target_commitish: '${{ steps.analyzeartifacts.outputs.commitish }}'
             });
@@ -206,8 +213,8 @@ jobs:
             core.setOutput('releaseId', releaseId);
 
   UploadArtifacts:
-    runs-on: [ windows-latest ]
     needs: [ CreateRelease ]
+    runs-on: [ windows-latest ]
     strategy:
       matrix: ${{ fromJson(needs.CreateRelease.outputs.artifacts) }}
       fail-fast: true
@@ -216,13 +223,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -259,7 +266,7 @@ jobs:
             });
 
       - name: Deliver to NuGet
-        uses: microsoft/AL-Go-Actions/Deliver@v4.0
+        uses: microsoft/AL-Go/Actions/Deliver@fc491ffce4cc911d677b3b4318a9372fbe54141e
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).nuGetContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -272,7 +279,7 @@ jobs:
           atypes: 'Apps,TestApps'
 
       - name: Deliver to Storage
-        uses: microsoft/AL-Go-Actions/Deliver@v4.0
+        uses: microsoft/AL-Go/Actions/Deliver@fc491ffce4cc911d677b3b4318a9372fbe54141e
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).storageContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -285,9 +292,9 @@ jobs:
           atypes: 'Apps,TestApps,Dependencies'
 
   CreateReleaseBranch:
-    if: ${{ github.event.inputs.createReleaseBranch=='Y' }}
-    runs-on: [ windows-latest ]
     needs: [ CreateRelease, UploadArtifacts ]
+    if: ${{ github.event.inputs.createReleaseBranch=='true' }}
+    runs-on: [ windows-latest ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -304,18 +311,18 @@ jobs:
           git push origin ${{ needs.CreateRelease.outputs.releaseBranch }}
 
   UpdateVersionNumber:
+    needs: [ CreateRelease, UploadArtifacts ]
     if: ${{ github.event.inputs.updateVersionNumber!='' }}
     runs-on: [ windows-latest ]
-    needs: [ CreateRelease, UploadArtifacts ]
     steps:
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -323,7 +330,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Update Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v4.0
+        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -332,16 +339,16 @@ jobs:
           directCommit: ${{ github.event.inputs.directCommit }}
 
   PostProcess:
+    needs: [ CreateRelease, UploadArtifacts, CreateReleaseBranch, UpdateVersionNumber ]
     if: always()
     runs-on: [ windows-latest ]
-    needs: [ CreateRelease, UploadArtifacts, CreateReleaseBranch, UpdateVersionNumber ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0094"

--- a/.github/workflows/CreateTestApp.yaml
+++ b/.github/workflows/CreateTestApp.yaml
@@ -21,16 +21,17 @@ on:
         required: true
         default: '50000..99999'
       sampleCode:
-        description: Include Sample code (Y/N)
-        required: false
-        default: 'Y'
-      directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Include Sample code?
         type: boolean
+        default: true
+      directCommit:
+        description: Direct Commit?
+        type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -46,26 +47,32 @@ env:
 
 jobs:
   CreateTestApp:
+    needs: [ ]
     runs-on: [ windows-latest ]
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0095"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -73,7 +80,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v4.0
+        uses: microsoft/AL-Go/Actions/CreateApp@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -88,7 +95,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0095"

--- a/.github/workflows/Current.yaml
+++ b/.github/workflows/Current.yaml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   Initialization:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -27,6 +28,11 @@ jobs:
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -34,14 +40,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0101"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
@@ -52,7 +58,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v4.0
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -80,16 +86,16 @@ jobs:
       artifactsNameSuffix: 'Current'
 
   PostProcess:
+    needs: [ Initialization, Build ]
     if: always()
     runs-on: [ windows-latest ]
-    needs: [ Initialization, Build ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0101"

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -1,0 +1,71 @@
+name: ' Deploy Reference Documentation'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: read
+  pages: write
+  id-token: write
+
+defaults:
+  run:
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+
+jobs:
+  DeployALDoc:
+    runs-on: [ windows-latest ]
+    name: Deploy Reference Documentation
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize the workflow
+        id: init
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+          eventId: "DO0097"
+        
+      - name: Read settings
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
+      - name: Determine Deployment Environments
+        id: DetermineDeploymentEnvironments
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          shell: powershell
+          getEnvironments: 'github-pages'
+          type: 'Publish'
+            
+      - name: Setup Pages
+        if: steps.DetermineDeploymentEnvironments.outputs.deployALDocArtifact == 1
+        uses: actions/configure-pages@v3
+        
+      - name: Build Reference Documentation
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+          artifacts: 'latest'
+        
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ".aldoc/_site/"
+        
+      - name: Deploy to GitHub Pages
+        if: steps.DetermineDeploymentEnvironments.outputs.deployALDocArtifact == 1
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -5,20 +5,21 @@ run-name: "Increment Version Number in [${{ github.ref_name }}]"
 on:
   workflow_dispatch:
     inputs:
-      project:
-        description: Project name if the repository is setup for multiple projects (* for all projects)
+      projects:
+        description: Comma-separated list of project name patterns if the repository is setup for multiple projects (default is * for all projects)
         required: false
         default: '*'
       versionNumber:
         description: Updated Version Number. Use Major.Minor for absolute change, use +Major.Minor for incremental change.
         required: true
       directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Direct Commit?
         type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -34,26 +35,32 @@ env:
 
 jobs:
   IncrementVersionNumber:
+    needs: [ ]
     runs-on: [ windows-latest ]
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0096"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -61,18 +68,18 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v4.0
+        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          project: ${{ github.event.inputs.project }}
+          projects: ${{ github.event.inputs.projects }}
           versionNumber: ${{ github.event.inputs.versionNumber }}
           directCommit: ${{ github.event.inputs.directCommit }}
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0096"

--- a/.github/workflows/NextMajor.yaml
+++ b/.github/workflows/NextMajor.yaml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   Initialization:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -27,6 +28,11 @@ jobs:
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -34,14 +40,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0099"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
@@ -52,7 +58,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v4.0
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -80,16 +86,16 @@ jobs:
       artifactsNameSuffix: 'NextMajor'
 
   PostProcess:
+    needs: [ Initialization, Build ]
     if: always()
     runs-on: [ windows-latest ]
-    needs: [ Initialization, Build ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0099"

--- a/.github/workflows/NextMinor.yaml
+++ b/.github/workflows/NextMinor.yaml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   Initialization:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -27,6 +28,11 @@ jobs:
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -34,14 +40,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0100"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
@@ -52,7 +58,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v4.0
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -80,16 +86,16 @@ jobs:
       artifactsNameSuffix: 'NextMinor'
 
   PostProcess:
+    needs: [ Initialization, Build ]
     if: always()
     runs-on: [ windows-latest ]
-    needs: [ Initialization, Build ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0100"

--- a/.github/workflows/PublishToEnvironment.yaml
+++ b/.github/workflows/PublishToEnvironment.yaml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   Initialization:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -33,25 +34,30 @@ jobs:
       deploymentEnvironmentsJson: ${{ steps.DetermineDeploymentEnvironments.outputs.DeploymentEnvironmentsJson }}
       deviceCode: ${{ steps.Authenticate.outputs.deviceCode }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0097"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v4.0
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@fc491ffce4cc911d677b3b4318a9372fbe54141e
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -69,7 +75,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         with:
           shell: powershell
@@ -101,7 +107,7 @@ jobs:
             Write-Host "No AuthContext provided for $envName, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v4.0/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go/fc491ffce4cc911d677b3b4318a9372fbe54141e/Actions/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -132,13 +138,13 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -146,7 +152,7 @@ jobs:
 
       - name: Deploy
         id: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v4.0
+        uses: microsoft/AL-Go/Actions/Deploy@fc491ffce4cc911d677b3b4318a9372fbe54141e
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -157,16 +163,16 @@ jobs:
           deploymentEnvironmentsJson: ${{ needs.Initialization.outputs.deploymentEnvironmentsJson }}
 
   PostProcess:
+    needs: [ Initialization, Deploy ]
     if: always()
     runs-on: [ windows-latest ]
-    needs: [ Initialization, Deploy ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0097"

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -27,7 +27,7 @@ jobs:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
     runs-on: [ windows-latest ]
     steps:
-      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@v4.0
+      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@fc491ffce4cc911d677b3b4318a9372fbe54141e
 
   Initialization:
     needs: [ PregateCheck ]
@@ -40,8 +40,14 @@ jobs:
       projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
       projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
+      baselineWorkflowRunId: ${{ steps.determineProjectsToBuild.outputs.BaselineWorkflowRunId }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -50,14 +56,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0104"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
 
@@ -68,7 +74,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v4.0
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -92,19 +98,20 @@ jobs:
       projectName: ${{ matrix.projectName }}
       buildMode: ${{ matrix.buildMode }}
       projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      baselineWorkflowRunId: ${{ needs.Initialization.outputs.baselineWorkflowRunId }}
       secrets: 'licenseFileUrl,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
       publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
       artifactsNameSuffix: 'PR${{ github.event.number }}'
 
   StatusCheck:
-    runs-on: [ windows-latest ]
     needs: [ Initialization, Build ]
     if: (!cancelled())
+    runs-on: [ windows-latest ]
     name: Pull Request Status Check
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: microsoft/AL-Go-Actions/PullRequestStatusCheck@v4.0
+        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@fc491ffce4cc911d677b3b4318a9372fbe54141e
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -1,0 +1,37 @@
+name: 'Troubleshooting'
+
+on:
+  workflow_dispatch:
+    inputs:
+      displayNameOfSecrets:
+        description: Display the name (not the value) of secrets available to the repository
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: read
+
+defaults:
+  run:
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+
+jobs:
+  Troubleshooting:
+    runs-on: [ windows-latest ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Troubleshooting
+        uses: microsoft/AL-Go/Actions/Troubleshooting@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+          gitHubSecrets: ${{ toJson(secrets) }}
+          displayNameOfSecrets: ${{ github.event.inputs.displayNameOfSecrets }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -4,13 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       templateUrl:
-        description: Template Repository URL (current is {TEMPLATEURL})
+        description: Template Repository URL (current is https://github.com/freddydk/MyPTE@preview)
         required: false
         default: ''
+      downloadLatest:
+        description: Download latest from template repository
+        type: boolean
+        default: true
       directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
+        description: Direct Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -25,27 +29,33 @@ env:
 
 jobs:
   UpdateALGoSystemFiles:
+    needs: [ ]
     runs-on: [ windows-latest ]
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0098"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           get: templateUrl
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -62,33 +72,37 @@ jobs:
             Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "templateUrl=$templateUrl"
           }
 
-      - name: Calculate DirectCommit
+      - name: Calculate Input
         env:
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: '${{ github.event.inputs.directCommit }}'
+          downloadLatest: ${{ github.event.inputs.downloadLatest }}
           eventName: ${{ github.event_name }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $directCommit = $ENV:directCommit
+          $downloadLatest = $ENV:downloadLatest
           Write-Host $ENV:eventName
           if ($ENV:eventName -eq 'schedule') {
-            Write-Host "Running Update AL-Go System Files on a schedule. Setting DirectCommit = Y"
-            $directCommit = 'Y'
+            Write-Host "Running Update AL-Go System Files on a schedule. Setting DirectCommit and DownloadLatest to true"
+            $directCommit = 'true'
+            $downloadLatest = 'true'
           }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "DirectCommit=$directCommit"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "directCommit=$directCommit"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v4.0
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
-          Update: Y
+          downloadLatest: ${{ env.downloadLatest }}
+          update: 'Y'
           templateUrl: ${{ env.templateUrl }}
           directCommit: ${{ env.directCommit }}
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@fc491ffce4cc911d677b3b4318a9372fbe54141e
         with:
           shell: powershell
           eventId: "DO0098"

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -36,6 +36,11 @@ on:
         description: Build mode used when building the artifacts
         required: true
         type: string
+      baselineWorkflowRunId:
+        description: ID of the baseline workflow run, from where to download the current project dependencies, in case they are not built in the current workflow run
+        required: false
+        default: '0'
+        type: string
       secrets:
         description: A comma-separated string with the names of the secrets, required for the workflow.
         required: false
@@ -43,14 +48,12 @@ on:
         type: string
       publishThisBuildArtifacts:
         description: Flag indicating whether this build artifacts should be published
-        required: false
-        default: false
         type: boolean
+        default: false
       publishArtifacts:
         description: Flag indicating whether the artifacts should be published
-        required: false
-        default: false
         type: boolean
+        default: false
       artifactsNameSuffix:
         description: Suffix to add to the artifacts names
         required: false
@@ -58,14 +61,12 @@ on:
         type: string
       signArtifacts:
         description: Flag indicating whether the apps should be signed
-        required: false
-        default: false
         type: boolean
+        default: false
       useArtifactCache:
         description: Flag determining whether to use the Artifacts Cache
-        required: false
-        default: false
         type: boolean
+        default: false
       parentTelemetryScopeJson:
         description: Specifies the telemetry scope for the telemetry signal
         required: false
@@ -77,179 +78,192 @@ env:
 
 jobs:
   BuildALGoProject:
+    needs: [ ]
     runs-on: ${{ fromJson(inputs.runsOn) }}
+    defaults:
+      run:
+        shell: ${{ inputs.shell }}
     name: ${{ inputs.projectName }} (${{ inputs.buildMode }})
     steps:
-        - name: Checkout
-          uses: actions/checkout@v3
-          with:
-            ref: ${{ inputs.checkoutRef }}
-            lfs: true
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkoutRef }}
+          lfs: true
 
-        - name: Read settings
-          uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
-          with:
-            shell: ${{ inputs.shell }}
-            project: ${{ inputs.project }}
-            get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact
+      - name: Read settings
+        uses: microsoft/AL-Go/Actions/ReadSettings@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: ${{ inputs.shell }}
+          project: ${{ inputs.project }}
+          get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact,generateDependencyArtifact
 
-        - name: Read secrets
-          id: ReadSecrets
-          if: github.event_name != 'pull_request'
-          uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
-          with:
-            shell: ${{ inputs.shell }}
-            gitHubSecrets: ${{ toJson(secrets) }}
-            getSecrets: '${{ inputs.secrets }},appDependencyProbingPathsSecrets'
+      - name: Read secrets
+        id: ReadSecrets
+        if: github.event_name != 'pull_request'
+        uses: microsoft/AL-Go/Actions/ReadSecrets@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: ${{ inputs.shell }}
+          gitHubSecrets: ${{ toJson(secrets) }}
+          getSecrets: '${{ inputs.secrets }},appDependencyProbingPathsSecrets'
 
-        - name: Determine ArtifactUrl
-          uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v4.0
-          id: determineArtifactUrl
-          with:
-            shell: ${{ inputs.shell }}
-            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-            project: ${{ inputs.project }}
+      - name: Determine ArtifactUrl
+        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        id: determineArtifactUrl
+        with:
+          shell: ${{ inputs.shell }}
+          parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+          project: ${{ inputs.project }}
 
-        - name: Cache Business Central Artifacts
-          if: env.useCompilerFolder == 'True' && inputs.useArtifactCache && env.artifactCacheKey
-          uses: actions/cache@v3
-          with:
-            path: .artifactcache
-            key: ${{ env.artifactCacheKey }}
+      - name: Cache Business Central Artifacts
+        if: env.useCompilerFolder == 'True' && inputs.useArtifactCache && env.artifactCacheKey
+        uses: actions/cache@v3
+        with:
+          path: .artifactcache
+          key: ${{ env.artifactCacheKey }}
 
-        - name: Download Project Dependencies
-          id: DownloadProjectDependencies
-          uses: microsoft/AL-Go-Actions/DownloadProjectDependencies@v4.0
-          env:
-            Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
-          with:
-            shell: ${{ inputs.shell }}
-            project: ${{ inputs.project }}
-            buildMode: ${{ inputs.buildMode }}
-            projectsDependenciesJson: ${{ inputs.projectDependenciesJson }}
+      - name: Download Project Dependencies
+        id: DownloadProjectDependencies
+        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        env:
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
+        with:
+          shell: ${{ inputs.shell }}
+          project: ${{ inputs.project }}
+          buildMode: ${{ inputs.buildMode }}
+          projectsDependenciesJson: ${{ inputs.projectDependenciesJson }}
+          baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
-        - name: Run pipeline
-          id: RunPipeline
-          uses: microsoft/AL-Go-Actions/RunPipeline@v4.0
-          env:
-            Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
-            BuildMode: ${{ inputs.buildMode }}
-          with:
-            shell: ${{ inputs.shell }}
-            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-            artifact: ${{ env.artifact }}
-            project: ${{ inputs.project }}
-            buildMode: ${{ inputs.buildMode }}
-            installAppsJson: ${{ steps.DownloadProjectDependencies.outputs.DownloadedApps }}
-            installTestAppsJson: ${{ steps.DownloadProjectDependencies.outputs.DownloadedTestApps }}
+      - name: Build
+        uses: microsoft/AL-Go/Actions/RunPipeline@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        env:
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
+          BuildMode: ${{ inputs.buildMode }}
+        with:
+          shell: ${{ inputs.shell }}
+          parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+          artifact: ${{ env.artifact }}
+          project: ${{ inputs.project }}
+          buildMode: ${{ inputs.buildMode }}
+          installAppsJson: ${{ steps.DownloadProjectDependencies.outputs.DownloadedApps }}
+          installTestAppsJson: ${{ steps.DownloadProjectDependencies.outputs.DownloadedTestApps }}
 
-        - name: Sign
-          if: inputs.signArtifacts && env.doNotSignApps == 'False' && env.keyVaultCodesignCertificateName != ''
-          id: sign
-          uses: microsoft/AL-Go-Actions/Sign@v4.0
-          with:
-            shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-            azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
-            pathToFiles: '${{ inputs.project }}/.buildartifacts/Apps/*.app'
-            parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+      - name: Sign
+        if: inputs.signArtifacts && env.doNotSignApps == 'False' && env.keyVaultCodesignCertificateName != ''
+        id: sign
+        uses: microsoft/AL-Go/Actions/Sign@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+          azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
+          pathToFiles: '${{ inputs.project }}/.buildartifacts/Apps/*.app'
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
-        - name: Calculate Artifact names
-          id: calculateArtifactsNames
-          uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v4.0
-          if: success() || failure()
-          with:
-            shell: ${{ inputs.shell }}
-            project: ${{ inputs.project }}
-            buildMode: ${{ inputs.buildMode }}
-            suffix: ${{ inputs.artifactsNameSuffix }}
+      - name: Calculate Artifact names
+        id: calculateArtifactsNames
+        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        if: success() || failure()
+        with:
+          shell: ${{ inputs.shell }}
+          project: ${{ inputs.project }}
+          buildMode: ${{ inputs.buildMode }}
+          suffix: ${{ inputs.artifactsNameSuffix }}
 
-        - name: Upload thisbuild artifacts - apps
-          if: inputs.publishThisBuildArtifacts
-          uses: actions/upload-artifact@v3
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildAppsArtifactsName }}
-            path: '${{ inputs.project }}/.buildartifacts/Apps/'
-            if-no-files-found: ignore
-            retention-days: 1
+      - name: Upload thisbuild artifacts - apps
+        if: inputs.publishThisBuildArtifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildAppsArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/Apps/'
+          if-no-files-found: ignore
+          retention-days: 1
 
-        - name: Upload thisbuild artifacts - test apps
-          if: inputs.publishThisBuildArtifacts
-          uses: actions/upload-artifact@v3
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildTestAppsArtifactsName }}
-            path: '${{ inputs.project }}/.buildartifacts/TestApps/'
-            if-no-files-found: ignore
-            retention-days: 1
+      - name: Upload thisbuild artifacts - dependencies
+        if: inputs.publishThisBuildArtifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildDependenciesArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
+          if-no-files-found: ignore
+          retention-days: 1
 
-        - name: Publish artifacts - apps
-          uses: actions/upload-artifact@v3
-          if: inputs.publishArtifacts
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.AppsArtifactsName }}
-            path: '${{ inputs.project }}/.buildartifacts/Apps/'
-            if-no-files-found: ignore
+      - name: Upload thisbuild artifacts - test apps
+        if: inputs.publishThisBuildArtifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildTestAppsArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/TestApps/'
+          if-no-files-found: ignore
+          retention-days: 1
 
-        - name: Publish artifacts - dependencies
-          uses: actions/upload-artifact@v3
-          if: inputs.publishArtifacts
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.DependenciesArtifactsName }}
-            path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
-            if-no-files-found: ignore
+      - name: Publish artifacts - apps
+        uses: actions/upload-artifact@v3
+        if: inputs.publishArtifacts
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.AppsArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/Apps/'
+          if-no-files-found: ignore
 
-        - name: Publish artifacts - test apps
-          uses: actions/upload-artifact@v3
-          if: inputs.publishArtifacts
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.TestAppsArtifactsName }}
-            path: '${{ inputs.project }}/.buildartifacts/TestApps/'
-            if-no-files-found: ignore
+      - name: Publish artifacts - dependencies
+        uses: actions/upload-artifact@v3
+        if: inputs.publishArtifacts && env.generateDependencyArtifact == 'True'
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.DependenciesArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
+          if-no-files-found: ignore
 
-        - name: Publish artifacts - build output
-          uses: actions/upload-artifact@v3
-          if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',inputs.project)) != '')
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.BuildOutputArtifactsName }}
-            path: '${{ inputs.project }}/BuildOutput.txt'
-            if-no-files-found: ignore
+      - name: Publish artifacts - test apps
+        uses: actions/upload-artifact@v3
+        if: inputs.publishArtifacts
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.TestAppsArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/TestApps/'
+          if-no-files-found: ignore
 
-        - name: Publish artifacts - container event log
-          uses: actions/upload-artifact@v3
-          if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',inputs.project)) != '')
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.ContainerEventLogArtifactsName }}
-            path: '${{ inputs.project }}/ContainerEventLog.evtx'
-            if-no-files-found: ignore
+      - name: Publish artifacts - build output
+        uses: actions/upload-artifact@v3
+        if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',inputs.project)) != '')
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.BuildOutputArtifactsName }}
+          path: '${{ inputs.project }}/BuildOutput.txt'
+          if-no-files-found: ignore
 
-        - name: Publish artifacts - test results
-          uses: actions/upload-artifact@v3
-          if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',inputs.project)) != '')
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.TestResultsArtifactsName }}
-            path: '${{ inputs.project }}/TestResults.xml'
-            if-no-files-found: ignore
+      - name: Publish artifacts - container event log
+        uses: actions/upload-artifact@v3
+        if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',inputs.project)) != '')
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.ContainerEventLogArtifactsName }}
+          path: '${{ inputs.project }}/ContainerEventLog.evtx'
+          if-no-files-found: ignore
 
-        - name: Publish artifacts - bcpt test results
-          uses: actions/upload-artifact@v3
-          if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',inputs.project)) != '')
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.BcptTestResultsArtifactsName }}
-            path: '${{ inputs.project }}/bcptTestResults.json'
-            if-no-files-found: ignore
+      - name: Publish artifacts - test results
+        uses: actions/upload-artifact@v3
+        if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',inputs.project)) != '')
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.TestResultsArtifactsName }}
+          path: '${{ inputs.project }}/TestResults.xml'
+          if-no-files-found: ignore
 
-        - name: Analyze Test Results
-          id: analyzeTestResults
-          if: (success() || failure()) && env.doNotRunTests == 'False'
-          uses: microsoft/AL-Go-Actions/AnalyzeTests@v4.0
-          with:
-            shell: ${{ inputs.shell }}
-            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-            project: ${{ inputs.project }}
+      - name: Publish artifacts - bcpt test results
+        uses: actions/upload-artifact@v3
+        if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',inputs.project)) != '')
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.BcptTestResultsArtifactsName }}
+          path: '${{ inputs.project }}/bcptTestResults.json'
+          if-no-files-found: ignore
 
-        - name: Cleanup
-          if: always()
-          uses: microsoft/AL-Go-Actions/PipelineCleanup@v4.0
-          with:
-            shell: ${{ inputs.shell }}
-            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-            project: ${{ inputs.project }}
+      - name: Analyze Test Results
+        id: analyzeTestResults
+        if: (success() || failure()) && env.doNotRunTests == 'False'
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: ${{ inputs.shell }}
+          parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+          project: ${{ inputs.project }}
+
+      - name: Cleanup
+        if: always()
+        uses: microsoft/AL-Go/Actions/PipelineCleanup@fc491ffce4cc911d677b3b4318a9372fbe54141e
+        with:
+          shell: ${{ inputs.shell }}
+          parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+          project: ${{ inputs.project }}


### PR DESCRIPTION
## Preview

Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.

### New Settings
- `templateSha`: The SHA of the version of AL-Go currently used

### New Actions
- `DumpWorkflowInfo`: Dump information about running workflow
- `Troubleshooting` : Run troubleshooting for repository

### Update AL-Go System Files
Add another parameter when running Update AL-Go System Files, called downloadLatest, used to indicate whether to download latest version from template repository. Default value is true.
If false, the templateSha repository setting is used to download specific AL-Go System Files when calculating new files.

### Issues
- Issue 782 Exclude '.altestrunner/' from template .gitignore
- Issue 823 Dependencies from prior build jobs are not included when using useProjectDependencies
- App artifacts for version 'latest' are now fetched from the latest CICD run that completed and successfully built all the projects for the corresponding branch.
- Issue 824 Utilize `useCompilerFolder` setting when creating an development environment for an AL-Go project.
- Issue 828 and 825 display warnings for secrets, which might cause AL-Go for GitHub to malfunction

### New Settings

- `alDoc` : JSON object with properties for the ALDoc reference document generation
  - **continuousDeployment** = Determines if reference documentation will be deployed continuously as part of CI/CD. You can run the **Deploy Reference Documentation** workflow to deploy manually or on a schedule. (Default false)
  - **deployToGitHubPages** = Determines whether or not the reference documentation site should be deployed to GitHub Pages for the repository. In order to deploy to GitHub Pages, GitHub Pages must be enabled and set to GitHub Actions. (Default true)
  - **maxReleases** = Maximum number of releases to include in the reference documentation. (Default 3)
  - **groupByProject** = Determines whether projects in multi-project repositories are used as folders in reference documentation
  - **includeProjects** = An array of projects to include in the reference documentation. (Default all)
  - **excludeProjects** = An array of projects to exclude in the reference documentation. (Default none)-
  - **header** = Header for the documentation site. (Default: Documentation for...)
  - **footer** = Footer for the documentation site. (Default: Made with...)
  - **defaultIndexMD** = Markdown for the landing page of the documentation site. (Default: Reference documentation...)
  - **defaultReleaseMD** = Markdown for the landing page of the release sites. (Default: Release reference documentation...)
  - *Note that in header, footer, defaultIndexMD and defaultReleaseMD you can use the following placeholders: {REPOSITORY}, {VERSION}, {INDEXTEMPLATERELATIVEPATH}, {RELEASENOTES}* 

### New Workflows
- **Deploy Reference Documentation** is a workflow, which you can invoke manually or on a schedule to generate and deploy reference documentation using the aldoc tool, using the ALDoc setting properties described above.
- **Troubleshooting** is a workflow, which you can invoke manually to run troubleshooting on the repository and check for settings or secrets, containing illegal values. When creating issues on https://github.com/microsoft/AL-Go/issues, we might ask you to run the troubleshooter to help identify common problems.

### Support for ALDoc reference documentation tool
ALDoc reference documentation tool is now supported for generating and deploying reference documentation for your projects either continuously or manually/scheduled.

